### PR TITLE
Refactored deprecated function

### DIFF
--- a/app/filters.php
+++ b/app/filters.php
@@ -124,7 +124,7 @@ add_filter('excerpt_more', function () {
  * Minimize inserter interactions.
  * @link https://developer.wordpress.org/block-editor/developers/filters/block-filters/#managing-block-categories
  */
-add_filter('block_categories', function ($categories, $post) {
+add_filter('block_categories_all', function ($categories, $post) {
     return [[
         'slug'  => 'blocks',
         'title' => __('Blocks', 'pcc'),


### PR DESCRIPTION
* [X] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [X] This is not a duplicate of an existing pull request

## Description

Replaces deprecated "block_categories" function from wordpress version 5.8 with its updated version "block_categories_all"

## Steps to test

1. Check if there is any deprecated function warning when editing pages

**Expected behavior: No deprecated function warning should be displayed

## Additional information

This change depends on updating WordPress to version 5.8