### PR TITLE
Adjust spacing in the main menu

### DIFF
--- a/resources/assets/styles/layouts/_header.css
+++ b/resources/assets/styles/layouts/_header.css
@@ -457,7 +457,7 @@ body .banner .nav .menu-item--languages button svg {
   }
 
   body .banner .nav > li + li {
-    margin-left: 18px;
+    margin-left: 5px;
   }
 
   body .no-js .banner .nav {


### PR DESCRIPTION
* [X] I have read the [guidelines for contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [X] This is not a duplicate of an existing pull request

## Description

Spaces between main menu items have been reduced to accommodate larger items

## Steps to test

1. It is necessary to run the command "npm run build" in the project theme
2. Check the spacing between items in the main menu

**Expected behavior:** <!-- What should happen -->

The spacing between the menus must be 5px