### PR TITLE
Add role "Affiliated Advisors" on People Page

### DIFF
--- a/app/Controllers/Page.php
+++ b/app/Controllers/Page.php
@@ -219,6 +219,11 @@ class Page extends Controller
     {
         return Page::peopleQuery('research-affilliate-institute');
     }
+    
+    public function affiliatedAdvisorsInstituteQuery()
+    {
+        return Page::peopleQuery('affiliated-advisors-institute');
+    }
 
     public static function peopleQuery($role = false)
     {

--- a/resources/views/page-people.blade.php
+++ b/resources/views/page-people.blade.php
@@ -31,7 +31,11 @@
         [
           'title' => __('Student Fellows', 'pcc'),
           'query' => $student_fellows_query,
-        ]
+        ],
+        [
+          'title' => __('Affiliated Advisors', 'pcc'),
+          'query' => $affiliated_advisors_institute_query,
+        ],
         ] as $query)
         @if ($query['query']->have_posts())
         <div class="wp-block-group">


### PR DESCRIPTION
* [X] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [X] This isn't a duplicate of an existing pull request

## Description

<!-- Description of the pull request -->

## Steps to test

1. Go to the page: https://platform.coop/who-we-are/people/
2. Make sure the "Affiliated Advisors" role is displayed before the "Student Fellows"

**Expected behavior:**
The "Affiliated Advisors" role should be available on the "https://platform.coop/who-we-are/people/" page

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here. -->

http://redmine.coopersystem.com.br/issues/70446
