### PR TITLE
Add new template page "Blog"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "log1x/blade-svg-sage": "^2.0",
     "log1x/sage-directives": "^1.0",
     "roots/sage-lib": "~9.0.9",
-    "soberwp/controller": "~2.1.0"
+    "soberwp/controller": "~2.1.0",
+    "htmlburger/carbon-fields": "^3.3"
   },
   "require-dev": {
     "roots/sage-installer": "~1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a706977446ce39ca42b87ceade82358",
+    "content-hash": "dd6b088f81b655d84eb169054fbcf610",
     "packages": [
         {
             "name": "brain/hierarchy",
@@ -255,6 +255,145 @@
                 "string"
             ],
             "time": "2018-01-09T20:05:19+00:00"
+        },
+        {
+            "name": "htmlburger/carbon-fields",
+            "version": "v3.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/htmlburger/carbon-fields.git",
+                "reference": "2ae6773c004b873a1b0456613b14852c1a436a96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/htmlburger/carbon-fields/zipball/2ae6773c004b873a1b0456613b14852c1a436a96",
+                "reference": "2ae6773c004b873a1b0456613b14852c1a436a96",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.7",
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon_Fields\\": "core/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "htmlBurger",
+                    "email": "wordpress@htmlburger.com",
+                    "homepage": "https://htmlburger.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Miroslav Mitev",
+                    "email": "mmitev.2create@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Atanas Angelov",
+                    "email": "atanas.angelov.dev@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Georgi Stoyanov",
+                    "email": "stoyanov.gs@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Plamen Kostadinov",
+                    "email": "pkostadinov.2create@gmail.com",
+                    "homepage": "http://plasmen.info/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Stanimir Panchev",
+                    "email": "Stan4omir@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Marin Atanasov",
+                    "email": "contact@marinatanasov.com",
+                    "homepage": "http://marinatanasov.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Siyan Panayotov",
+                    "homepage": "http://siyanpanayotov.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Peter Petrov",
+                    "email": "peter.petrov89@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Stanimir Stoyanov",
+                    "email": "stanimir.k.stoyanov@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Kaloyan Ivanov",
+                    "email": "kaloyanxivanov@gmail.com",
+                    "homepage": "http://vilepixels.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Georgi Popov",
+                    "homepage": "http://magadanski.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "German Velchev",
+                    "email": "germozy@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Rashko Petrov",
+                    "email": "brutalenemy666@gmail.com",
+                    "homepage": "http://errorfactory.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Alexander Panayotov",
+                    "email": "alexander.panayotov@gmail.com",
+                    "homepage": "http://alexanderpanayotov.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Viktor Vasilev",
+                    "email": "liberalcho@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Georgi Georgiev",
+                    "email": "george.georgiev96@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Atanas Vasilev",
+                    "email": "atanasvasilev91@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "WordPress developer-friendly custom fields for post types, taxonomy terms, users, comments, widgets, options and more.",
+            "homepage": "http://carbonfields.net/",
+            "support": {
+                "docs": "http://carbonfields.net/docs/",
+                "email": "wordpress@htmlburger.com",
+                "issues": "https://github.com/htmlburger/carbon-fields/issues",
+                "source": "https://github.com/htmlburger/carbon-fields"
+            },
+            "time": "2022-05-05T14:49:59+00:00"
         },
         {
             "name": "illuminate/config",
@@ -1832,5 +1971,6 @@
     "platform": {
         "php": ">=7.1"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }

--- a/custom-fields/fields/pages.php
+++ b/custom-fields/fields/pages.php
@@ -12,7 +12,7 @@ function pages() {
 
     $args = [
         'hide_empty' => 1,
-        'exclude' => array_merge([1], $uncat_categories),
+        'exclude' => $uncat_categories,
     ];
     $categories = array_column(get_categories($args), 'name', 'term_id');
 

--- a/custom-fields/fields/pages.php
+++ b/custom-fields/fields/pages.php
@@ -1,0 +1,26 @@
+<?php
+use Carbon_Fields\Container;
+use Carbon_Fields\Field;
+
+function pages() {
+    $uncat_categories = get_terms([
+        'taxonomy' => 'category',
+        'name' => 'Uncategorized',
+        'hide_empty' => true,
+    ]);
+    $uncat_categories = array_column($uncat_categories, 'term_id');
+
+    $args = [
+        'hide_empty' => 1,
+        'exclude' => array_merge([1], $uncat_categories),
+    ];
+    $categories = array_column(get_categories($args), 'name', 'term_id');
+
+    Container::make('post_meta', __('Custom fields'))
+        ->where('post_type', '=', 'page')
+        ->where('post_template', '=', 'views/page-custom-blog.blade.php')
+        ->add_fields([
+            Field::make('select', 'category', __('Select a category'))
+                ->set_options($categories)
+        ]);
+}

--- a/custom-fields/init.php
+++ b/custom-fields/init.php
@@ -16,6 +16,11 @@ class CustomFields
         \Carbon_Fields\Carbon_Fields::boot();
     }
 
+    public function load_fields() {
+        include 'fields/pages.php';
+
+        pages();
+    }
 }
 
 new CustomFields();

--- a/custom-fields/init.php
+++ b/custom-fields/init.php
@@ -1,0 +1,21 @@
+<?php
+
+use Carbon_Fields\Container;
+use Carbon_Fields\Field;
+
+class CustomFields
+{
+    public function __construct() {
+        add_action('after_setup_theme', array($this, 'load_carbon_fields'));
+        add_action('carbon_fields_loaded', array($this, 'load_fields'));
+    }
+
+
+    public function load_carbon_fields() {
+        require_once get_template_directory() . '/../vendor/autoload.php';
+        \Carbon_Fields\Carbon_Fields::boot();
+    }
+
+}
+
+new CustomFields();

--- a/resources/functions.php
+++ b/resources/functions.php
@@ -94,3 +94,9 @@ Container::getInstance()
             'blocks' => require dirname(__DIR__).'/config/blocks.php',
         ]);
     }, true);
+
+
+/**
+ * Start the Carbon Fields
+ */
+require get_template_directory() . '/../custom-fields/init.php';

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,3 +1,14 @@
+@php
+  global $template;
+  $custom_temp = 'page-custom-blog.blade.php';
+  if (basename($template) === $custom_temp) {
+    add_filter('body_class', function ($classes) {
+      $classes = ['blog logged-in admin-bar no-customize-support wp-embed-responsive multi-author-false app-data index-data home-data'];
+      return $classes;
+    });
+  }
+@endphp
+
 <!doctype html>
 <html class="no-js" {!! get_language_attributes() !!}>
   @include('partials.head')

--- a/resources/views/page-custom-blog.blade.php
+++ b/resources/views/page-custom-blog.blade.php
@@ -1,5 +1,5 @@
 {{--
-  Template Name: Blog
+  Template Name: Blog Category View
 --}}
 
 @php

--- a/resources/views/page-custom-blog.blade.php
+++ b/resources/views/page-custom-blog.blade.php
@@ -1,0 +1,53 @@
+{{--
+  Template Name: Blog
+--}}
+
+@extends('layouts.app')
+
+@section('content')
+  @include('partials.page-header')
+    <div id="content">
+      <div class="wp-block-group">
+        <div class="cards cards--three-columns">
+        @if (!have_posts())
+          <div class="alert alert-warning">
+            {{ __('Sorry, no results were found.', 'pcc') }}
+          </div>
+          {!! get_search_form(false) !!}
+        @endif
+
+        @php
+            global $paged;
+            $curpage = $paged ? $paged : 1;
+            $args = [
+              'post_type' => 'post',
+              'showposts' => 12,
+              'orderby' => 'date',
+              'order'   => 'DESC',
+              // 'cat' => 3,
+              'paged' => $paged
+            ];
+            $blog_posts = new WP_Query($args);
+        @endphp
+        @while ($blog_posts->have_posts()) @php $blog_posts->the_post() @endphp
+          @include('partials.content-'.get_post_type())
+        @endwhile
+      </div>
+
+      <nav class="navigation pagination" aria-label="Posts">
+        {!!
+          paginate_links([
+            'base' => get_pagenum_link(1) . '%_%',
+            'format' => 'page/%#%',
+            'current' => max( 1, get_query_var( 'paged' ) ),
+            'total' => $blog_posts->max_num_pages,
+            'mid_size'    => 1,
+            'prev_text'    => __('‹ '),
+            'next_text'    => __(' ›'),
+          ]);
+          wp_reset_postdata();
+        !!}
+      </nav>
+    </div>
+  </div>
+@endsection

--- a/resources/views/page-custom-blog.blade.php
+++ b/resources/views/page-custom-blog.blade.php
@@ -2,6 +2,19 @@
   Template Name: Blog
 --}}
 
+@php
+  $args_paginate = [
+    'base' => get_pagenum_link(1) . '%_%',
+    'format' => 'page/%#%',
+    'current' => max( 1, get_query_var( 'paged' ) ),
+    'total' => $blog_posts->max_num_pages,
+    'mid_size'    => 1,
+    'prev_text'    => __('‹ '),
+    'next_text'    => __(' ›'),
+  ];
+  $paginate_links = paginate_links($args_paginate);
+@endphp
+
 @extends('layouts.app')
 
 @section('content')
@@ -35,18 +48,10 @@
       </div>
 
       <nav class="navigation pagination" aria-label="Posts">
-        {!!
-          paginate_links([
-            'base' => get_pagenum_link(1) . '%_%',
-            'format' => 'page/%#%',
-            'current' => max( 1, get_query_var( 'paged' ) ),
-            'total' => $blog_posts->max_num_pages,
-            'mid_size'    => 1,
-            'prev_text'    => __('‹ '),
-            'next_text'    => __(' ›'),
-          ]);
+        @php
+          echo $paginate_links;
           wp_reset_postdata();
-        !!}
+        @endphp
       </nav>
     </div>
   </div>

--- a/resources/views/page-custom-blog.blade.php
+++ b/resources/views/page-custom-blog.blade.php
@@ -3,6 +3,20 @@
 --}}
 
 @php
+  global $paged;
+  $curpage = $paged ? $paged : 1;
+  $category = carbon_get_the_post_meta('category') ?? -1;
+
+  $args_posts = [
+    'post_type' => 'post',
+    'showposts' => 12,
+    'orderby' => 'date',
+    'order'   => 'DESC',
+    'cat' => $category,
+    'paged' => $paged
+  ];
+  $blog_posts = new WP_Query($args_posts);
+
   $args_paginate = [
     'base' => get_pagenum_link(1) . '%_%',
     'format' => 'page/%#%',
@@ -28,20 +42,6 @@
           </div>
           {!! get_search_form(false) !!}
         @endif
-
-        @php
-            global $paged;
-            $curpage = $paged ? $paged : 1;
-            $args = [
-              'post_type' => 'post',
-              'showposts' => 12,
-              'orderby' => 'date',
-              'order'   => 'DESC',
-              // 'cat' => 3,
-              'paged' => $paged
-            ];
-            $blog_posts = new WP_Query($args);
-        @endphp
         @while ($blog_posts->have_posts()) @php $blog_posts->the_post() @endphp
           @include('partials.content-'.get_post_type())
         @endwhile


### PR DESCRIPTION
* [X] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [X] This is not a duplicate of an existing pull request

## Description

Create new posts page for "Courses" category

## Steps to test

1. Create a new page and select the "Blog" page template
2. A category selection field should appear
3. Choose a post category
3. Access the page created

**Expected behavior:**
Posts displayed must match the selected category

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

1. Carbon Fields has been installed in the theme in this branch
2. You need to update Composer to install carbon fields

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here. -->

http://redmine.coopersystem.com.br/issues/72359