### PR TITLE
Reduced padding between menu items

### DIFF
--- a/resources/assets/styles/layouts/_header.css
+++ b/resources/assets/styles/layouts/_header.css
@@ -315,7 +315,7 @@ body:not(.project) .banner .nav .menu-item--languages button svg {
     font-size: 1rem;
     font-weight: normal;
     min-height: 0;
-    padding: 17px 1rem;
+    padding: 17px .7rem;
   }
 
   body:not(.project) .banner .nav .menu-item--languages button {
@@ -334,9 +334,9 @@ body:not(.project) .banner .nav .menu-item--languages button svg {
     content: "";
     height: var(--border-medium);
     left: 0;
-    margin-left: 1rem;
+    margin-left: .7rem;
     position: absolute;
-    width: calc(100% - 2rem);
+    width: calc(100% - 1.4rem);
   }
 
   body:not(.project) .banner .nav a:hover,


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Reduced spacing between menu items, as the amount of items was breaking the layout

## Steps to test

1. After configuring all Wordpress and activating all plugins, check if the navbar items are correctly positioned

**Expected behavior:** Menu items may be out of container due to lack of space

## Additional information

It is necessary to run the command `npm run build` to apply the styles correctly
