### PR TITLE
Show embed links for all users

### DIFF
--- a/resources/views/partials/content-single-pcc-event-session.blade.php
+++ b/resources/views/partials/content-single-pcc-event-session.blade.php
@@ -5,22 +5,21 @@ $user_has_event = user_has_event($user_id, get_the_ID());
 @endphp
 
 <div class="entry-content" id="content">
-  @if(get_post_meta(get_the_ID(), 'pcc_event_oc_paid_event', true) && (!is_user_logged_in() || (is_user_logged_in() && $user_is_external_user && !$user_has_event)))
-    @if($oc_content = get_post_meta(get_the_ID(), 'pcc_event_oc_content_before_link', true))
-      {!! $oc_content !!}
-    @endif
-    @if($oc_event_url = get_post_meta(get_the_ID(), 'pcc_event_oc_event_link', true))
-      @php
-      $oc_event_embed_url = get_post_meta(get_the_ID(), 'pcc_event_oc_event_embed_link', true);
-      @endphp
-      @if($oc_event_embed_url && !empty($oc_event_embed_url))
-        <p><iframe src="{{$oc_event_embed_url}}" style="width: 100%; height: 130vh; border: none;"></iframe></p>
-      @else
-        <p><a class="payment" href="{{$oc_event_url}}" target="_blank">{{ __('Payment', 'pcc') }}</a></p>
-      @endif
-    @endif
-  @else
+  @if(!(get_post_meta(get_the_ID(), 'pcc_event_oc_paid_event', true) && (!is_user_logged_in() || (is_user_logged_in() && $user_is_external_user && !$user_has_event))))
     @content
+  @endif 
+  @if($oc_content = get_post_meta(get_the_ID(), 'pcc_event_oc_content_before_link', true))
+    {!! $oc_content !!}
+  @endif
+  @if($oc_event_url = get_post_meta(get_the_ID(), 'pcc_event_oc_event_link', true))
+    @php
+    $oc_event_embed_url = get_post_meta(get_the_ID(), 'pcc_event_oc_event_embed_link', true);
+    @endphp
+    @if($oc_event_embed_url && !empty($oc_event_embed_url))
+      <p><iframe src="{{$oc_event_embed_url}}" style="width: 100%; height: 130vh; border: none;"></iframe></p>
+    @else
+      <p><a class="payment" href="{{$oc_event_url}}" target="_blank">{{ __('Payment', 'pcc') }}</a></p>
+    @endif
   @endif
   @if(!empty(SinglePccEvent::eventParticipants()))
   <div class="wp-block-columns has-2-columns">

--- a/resources/views/partials/content-single-pcc-event.blade.php
+++ b/resources/views/partials/content-single-pcc-event.blade.php
@@ -5,22 +5,21 @@ $user_has_event = user_has_event($user_id, get_the_ID());
 @endphp
 
 <div class="entry-content" id="content">
-  @if(get_post_meta(get_the_ID(), 'pcc_event_oc_paid_event', true) && (!is_user_logged_in() || (is_user_logged_in() && $user_is_external_user && !$user_has_event)))
-    @if($oc_content = get_post_meta(get_the_ID(), 'pcc_event_oc_content_before_link', true))
-      {!! $oc_content !!}
-    @endif
-    @if($oc_event_url = get_post_meta(get_the_ID(), 'pcc_event_oc_event_link', true))
-      @php
-      $oc_event_embed_url = get_post_meta(get_the_ID(), 'pcc_event_oc_event_embed_link', true);
-      @endphp
-      @if($oc_event_embed_url && !empty($oc_event_embed_url))
-        <p><iframe src="{{$oc_event_embed_url}}" style="width: 100%; height: 130vh; border: none;"></iframe></p>
-      @else
-        <p><a class="payment" href="{{$oc_event_url}}" target="_blank">{{ __('Payment', 'pcc') }}</a></p>
-      @endif
-    @endif
-  @else
+  @if(!(get_post_meta(get_the_ID(), 'pcc_event_oc_paid_event', true) && (!is_user_logged_in() || (is_user_logged_in() && $user_is_external_user && !$user_has_event))))
     @content
+  @endif 
+  @if($oc_content = get_post_meta(get_the_ID(), 'pcc_event_oc_content_before_link', true))
+    {!! $oc_content !!}
+  @endif
+  @if($oc_event_url = get_post_meta(get_the_ID(), 'pcc_event_oc_event_link', true))
+    @php
+    $oc_event_embed_url = get_post_meta(get_the_ID(), 'pcc_event_oc_event_embed_link', true);
+    @endphp
+    @if($oc_event_embed_url && !empty($oc_event_embed_url))
+      <p><iframe src="{{$oc_event_embed_url}}" style="width: 100%; height: 130vh; border: none;"></iframe></p>
+    @else
+      <p><a class="payment" href="{{$oc_event_url}}" target="_blank">{{ __('Payment', 'pcc') }}</a></p>
+    @endif
   @endif
   @if(!empty(SinglePccEvent::eventParticipants(6)))
   <div class="wp-block-columns has-2-columns">


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

Embed links will be displayed for both logged in and unlogged users.

## Steps to test

1. Edit or create an event
2. Set the event as Paid event
3. Enter the Open Collective event url

**Expected behavior:** If the URL meets the requirements to be an embed link, an iframe will be shown, if not, a button to access the other site

## Additional information


