### PR TITLE
Add event languages and certificate fields

### DIFF
--- a/app/Controllers/SinglePccEvent.php
+++ b/app/Controllers/SinglePccEvent.php
@@ -360,6 +360,11 @@ class SinglePccEvent extends Controller
         return get_post_meta(get_the_ID(), 'pcc_event_timezone', true);
     }
 
+    public function eventCertificate()
+    {
+        return get_post_meta(get_the_ID(), 'pcc_event_certificate', true);
+    }
+
     public function eventRibbon()
     {
         global $post, $wp;

--- a/app/Controllers/SinglePccEvent.php
+++ b/app/Controllers/SinglePccEvent.php
@@ -235,6 +235,36 @@ class SinglePccEvent extends Controller
         return get_post_meta($post->post_parent, 'pcc_event_type', true);
     }
 
+    public function eventLanguage()
+    {
+        global $id;
+        $event_type = $this->eventType();
+
+        $languages = [
+            'en'=> 'English',
+            'pt'=> 'Portuguese',
+            'es'=> 'Spanish',
+            'it'=> 'Italian',
+            'tr'=> 'Turkish',
+            'ch'=> 'Chinese',
+            'th'=> 'Thai',
+        ];
+
+        if ($event_type === 'course' || $event_type === 'past_course') {
+            $event_language = get_post_meta($id, 'pcc_event_language', true);
+
+            if ($event_language) {
+                $event_second_language = get_post_meta($id, 'pcc_event_second_language', true);
+
+                return $event_second_language !== 'none' && $event_second_language !== null ? 
+                    $languages[ $event_language ] . ' + ' . $languages[ $event_second_language ] . __(' (Live Transl.)', 'pcc') :
+                    $languages[ $event_language ];
+            }
+        }
+
+        return false;
+    }
+
     public function eventTypeLabel()
     {
         global $id;
@@ -481,7 +511,7 @@ class SinglePccEvent extends Controller
         return get_post_meta($event_id, 'pcc_event_oc_paid_event', true);
     }
 
-    function userPurchasedEvent()
+    public function userPurchasedEvent()
     {
         global $post;
 

--- a/resources/views/events.blade.php
+++ b/resources/views/events.blade.php
@@ -6,6 +6,7 @@
   global $paged;
   $curpage = $paged ? $paged : 1;
   $event_type = carbon_get_the_post_meta('crb_event_type') ?? -1;
+  $exclude_paid_event_children = [];
 
   if ($event_type != 'all') {
     $meta_query = array(
@@ -17,6 +18,23 @@
     );
   }
 
+  $child_posts = get_posts([
+    'post_type' => 'pcc-event',
+    'posts_per_page' => -1,
+    'post_parent__not_in' => [0],
+    'fields' => 'ids',
+  ]);
+
+  foreach ($child_posts as $child_id) {
+    $event_parents = get_post_ancestors($child_id);
+    $parent_id = array_pop($event_parents);
+    $is_paid_event = get_post_meta($parent_id, 'pcc_event_oc_paid_event', true);
+
+    if ($is_paid_event) {
+      $exclude_paid_event_children[] = $child_id;
+    }
+  }
+
   $args_posts = [
     'post_type' => 'pcc-event',
     'posts_per_page' => 12,
@@ -24,6 +42,7 @@
     'order'   => 'DESC',
     'paged' => get_query_var('paged', 1),
     'meta_query' => $meta_query,
+    'post__not_in' => $exclude_paid_event_children,
   ];
 
   $events = new WP_Query($args_posts);

--- a/resources/views/partials/entry-card-meta.blade.php
+++ b/resources/views/partials/entry-card-meta.blade.php
@@ -1,7 +1,7 @@
 @php
   $post = get_post();
-  $event_type = get_post_meta($post->ID, 'pcc_event_type')[0];
-  $event_price = get_post_meta($post->ID, 'pcc_event_price')[0];
+  $event_type = get_post_meta($post->ID, 'pcc_event_type', true);
+  $event_price = get_post_meta($post->ID, 'pcc_event_price', true);
 @endphp
 @if($post->post_type == 'pcc-event' && ($event_type == 'course' || $event_type == 'past_course'))
     <div class="course-price">{!! $event_price ? $event_price . ' USD' : 'Free' !!}</div>

--- a/resources/views/partials/event-meta.blade.php
+++ b/resources/views/partials/event-meta.blade.php
@@ -11,11 +11,11 @@
     @if($post->post_type == 'pcc-event' && ($event_type == 'course' || $event_type == 'past_course'))
       <li><span>@svg('currency', ['aria-hidden' => 'true'])</span><p translate="no">{!! $event_price ?? 'Free' !!}</p></li>
     @endif
-    @if($event_language)
-    <li><span>@svg('web', ['aria-hidden' => 'true'])</span><p translate="no">{{ $event_language }}</p></li>
+    @if($event_certificate)
+      <li><span>@svg('certificate', ['aria-hidden' => 'true'])</span><p translate="no">{{ __('Certificate Course', 'pcc') }}</p></li>
     @endif
-    <!-- 
-    <li><span>@svg('certificate', ['aria-hidden' => 'true'])</span><p translate="no">Certificate Course</p></li>
-     -->
+    @if($event_language)
+      <li><span>@svg('web', ['aria-hidden' => 'true'])</span><p translate="no">{{ $event_language }}</p></li>
+    @endif
   </ul>
 </div>

--- a/resources/views/partials/event-meta.blade.php
+++ b/resources/views/partials/event-meta.blade.php
@@ -8,27 +8,14 @@
         <li><span>@svg('location', ['aria-hidden' => 'true'])</span><p translate="no">{!! trim(strip_tags($event_format, ['br'])) !!}</p></li>
       @endif
     @endif
-  @endif
-  @if($post->post_type == 'pcc-event' && ($event_type == 'course' || $event_type == 'past_course'))
-    <p class="price">@svg('price', ['aria-hidden' => 'true']) {!! $event_price ?? 'Free' !!}</p>
-  @endif
-</div>
-
-<div class="meta">
-  <ul>
-    <li><span>@svg('calendar', ['aria-hidden' => 'true'])</span><p>{{ $event_date }}</p></li>
-    @if($event_format)
-      @if($post->post_parent)
-        <li><span>@svg('location', ['aria-hidden' => 'true'])</span><p translate="no">{!! SinglePccEvent::sessionVenue($post->ID, $post->post_parent) !!}</p></li>
-      @else
-        <li><span>@svg('location', ['aria-hidden' => 'true'])</span><p translate="no">{!! trim(strip_tags($event_format, ['br'])) !!}</p></li>
-      @endif
-    @endif
     @if($post->post_type == 'pcc-event' && ($event_type == 'course' || $event_type == 'past_course'))
       <li><span>@svg('currency', ['aria-hidden' => 'true'])</span><p translate="no">{!! $event_price ?? 'Free' !!}</p></li>
     @endif
+    @if($event_language)
+    <li><span>@svg('web', ['aria-hidden' => 'true'])</span><p translate="no">{{ $event_language }}</p></li>
+    @endif
     <!-- 
     <li><span>@svg('certificate', ['aria-hidden' => 'true'])</span><p translate="no">Certificate Course</p></li>
-    <li><span>@svg('web', ['aria-hidden' => 'true'])</span><p translate="no">English + Spanish (Live Transl.)</p></li> -->
+     -->
   </ul>
 </div>


### PR DESCRIPTION
* [x] I've read the [guidelines for Contributing to the Platform Co-op Toolkit](https://github.com/platform-coop-toolkit/.github/blob/master/CONTRIBUTING.md)
* [x] This isn't a duplicate of an existing pull request

## Description

- Added course languages field in event meta;
- Added certificate course field in event meta;
- Removed child events from query when parent event is paid.

## Steps to test

1. Create an event and fill the fields;
2. See if the language and certificate fields will show on the side;
3. See if child events of paid events are showing in the course list.

## Additional information


